### PR TITLE
Added Bootstrap 3 'danger' alert type

### DIFF
--- a/src/flashular.coffee
+++ b/src/flashular.coffee
@@ -50,7 +50,7 @@ angular.module("flashular", [])
     """
   link: (scope, iElement, iAttrs) ->
     scope.flash = flash.now
-    scope.alertTypes = ["info", "success", "error", "warning"]
+    scope.alertTypes = ["info", "success", "error", "warning", "danger"]
     if not iAttrs.preProcess?
       # Define a default preProcess function that does no processing of the alert.
       scope.preProcess = (alert) -> $interpolate("{{alert}}")(alert)


### PR DESCRIPTION
Added 'danger' alert type which has replaced 'error' in Bootstrap 3. I've left 'error' in for continued < BS3 support.
